### PR TITLE
现在不会错误的放行非ccw url的扩展，可以自动生成空扩展

### DIFF
--- a/src/scene/home.js
+++ b/src/scene/home.js
@@ -536,6 +536,14 @@ export class HomeScene {
               break
             }
           }
+          const extname = extensionObject.getInfo().id;
+          if(confirm(`作品尝试注册扩展 ${extname}，是否自动生成空扩展？`)) {
+            const info = extensionObject.getInfo();
+            for(const block of info.blocks) {
+              const opc = block.opcode;
+              extensionObject[opc] = _=>{};
+            }
+          }
           _compilerRegisterExtension.call(vm.runtime, name, extensionObject)
         }
       })

--- a/src/scene/home.js
+++ b/src/scene/home.js
@@ -154,7 +154,7 @@ export class HomeScene {
           return async function (extensionURL, shouldReplace = false) {
             if (
               extensionURL.startsWith(
-                'https://m.ccw.site/user_projects_assets/'
+                'https://'
               )
             ) {
               let code = await fetch(extensionURL).then(res => res.text())


### PR DESCRIPTION
帮助熊谷凌实装